### PR TITLE
Upgrade to ember-cli-babel 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.18.0",
     "ember-cli-deploy-plugin": "0.2.6",
     "git-repo-info": "^1.3.0"
   },


### PR DESCRIPTION
This upgrades ember-cli-babel to the last release in the 6 series.

We could go higher and upgrade all the way to version `7.26.3`, the latest version, but [version `7.0.0` drops support for Ember versions below 2.13](https://github.com/babel/ember-cli-babel/blob/master/CHANGELOG.md#v700-2018-08-28) which would probably need a 1.0 release.